### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Step 2: Build Docker image
+      # Step 2: Get Resources
+      - name: Get Resources
+        run: |
+          curl -o schema.graphql https://docs.github.com/public/fpt/schema.docs.graphql
+
+      # Step 3: Build Docker image
       - name: Build Docker image
         run: docker build -t visfork-ci -f Dockerfile.build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Step 2: Get Resources
-      - name: Get Resources
+      # Step 2: Cache schema
+      - name: Cache schema
+        id: cache-schema
+        uses: actions/cache@v4
+        env: 
+          cache-name: cache-schema-gql
+        with:
+          path: ./
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('./schema.graphql') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
+
+
+      # Step 3: Get Resources
+      - if: ${{ steps.cache-schema.outputs.cache-hit != 'true' }}
+        name: Get resources
         run: |
           curl -o schema.graphql https://docs.github.com/public/fpt/schema.docs.graphql
 
-      # Step 3: Build Docker image
+      # Step 4: Build Docker image
       - name: Build Docker image
         run: docker build -t visfork-ci -f Dockerfile.build .
 
-      # Step 4: Run Tests
-      - name: Run Tests
+      # Step 5: Run Tests
+      - name: Run tests
         run: docker run --rm visfork-ci npm run test-slim
 
-      # Step 5: Build 
+      # Step 6: Build 
       - name: Build
         run: docker run --rm visfork-ci npm run build
 
-      # Step 6: TODO: Store the build artifact
+      # Step 7: TODO: Store the build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
 
       # Step 5: Build 
       - name: Build
-        run: docker run --rm visfork-ci npm run build-ts
+        run: docker run --rm visfork-ci npm run build
 
       # Step 6: TODO: Store the build artifact

--- a/codegen.ts
+++ b/codegen.ts
@@ -7,7 +7,6 @@ const config: CodegenConfig = {
       "./__generated__/": {
          preset: "client",
       },
-      
    },
 };
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": " eslint .",
     "test": "npm run test-coverage",
     "test-coverage": "jest --forceExit --coverage --verbose",
-    "test-slim": "jest --forceExit"
+    "test-slim": "jest --forceExit --passWithNoTests"
   },
   "author": "Ren Fu",
   "license": "MIT",

--- a/src/Placeholder.graphql
+++ b/src/Placeholder.graphql
@@ -1,0 +1,3 @@
+query Placeholder {
+    __typename
+}


### PR DESCRIPTION
This makes a few changes to CI:
It makes npm run build work without giving any errors, regardless of CI.
It doesnt raise any errors when it doesnt need to (no test files, inserted a placeholder query to prevent "no documents" graphql error)
Makes sure the schema is retrieved with curl and cached in the workflow (since GitHub Actions doesnt use the .devcontainer.json file, it never executes the postCreateCommand specified in there).
